### PR TITLE
Improve deserialization behavior if `null` are ignored

### DIFF
--- a/Source/AlphaVantage.Net/Fundamentals/BalanceSheetResponse.cs
+++ b/Source/AlphaVantage.Net/Fundamentals/BalanceSheetResponse.cs
@@ -20,41 +20,41 @@ public class BalanceSheetReport
 #pragma warning disable CS1591
 	public required DateOnly FiscalDateEnding { get; set; }
 	public required string ReportedCurrency { get; set; }
-	public required decimal? TotalAssets { get; set; }
-	public required decimal? TotalCurrentAssets { get; set; }
-	public required decimal? CashAndCashEquivalentsAtCarryingValue { get; set; }
-	public required decimal? CashAndShortTermInvestments { get; set; }
-	public required decimal? Inventory { get; set; }
-	public required decimal? CurrentNetReceivables { get; set; }
-	public required decimal? TotalNonCurrentAssets { get; set; }
-	public required decimal? PropertyPlantEquipment { get; set; }
-	public required decimal? AccumulatedDepreciationAmortizationPPE { get; set; }
-	public required decimal? IntangibleAssets { get; set; }
-	public required decimal? IntangibleAssetsExcludingGoodwill { get; set; }
-	public required decimal? Goodwill { get; set; }
-	public required decimal? Investments { get; set; }
-	public required decimal? LongTermInvestments { get; set; }
-	public required decimal? ShortTermInvestments { get; set; }
-	public required decimal? OtherCurrentAssets { get; set; }
-	public required decimal? OtherNonCurrentAssets { get; set; }
-	public required decimal? TotalLiabilities { get; set; }
-	public required decimal? TotalCurrentLiabilities { get; set; }
-	public required decimal? CurrentAccountsPayable { get; set; }
-	public required decimal? DeferredRevenue { get; set; }
-	public required decimal? CurrentDebt { get; set; }
-	public required decimal? ShortTermDebt { get; set; }
-	public required decimal? TotalNonCurrentLiabilities { get; set; }
-	public required decimal? CapitalLeaseObligations { get; set; }
-	public required decimal? LongTermDebt { get; set; }
-	public required decimal? CurrentLongTermDebt { get; set; }
-	public required decimal? LongTermDebtNoncurrent { get; set; }
-	public required decimal? ShortLongTermDebtTotal { get; set; }
-	public required decimal? OtherCurrentLiabilities { get; set; }
-	public required decimal? OtherNonCurrentLiabilities { get; set; }
-	public required decimal? TotalShareholderEquity { get; set; }
-	public required decimal? TreasuryStock { get; set; }
-	public required decimal? RetainedEarnings { get; set; }
-	public required decimal? CommonStock { get; set; }
-	public required decimal? CommonStockSharesOutstanding { get; set; }
+	public decimal? TotalAssets { get; set; }
+	public decimal? TotalCurrentAssets { get; set; }
+	public decimal? CashAndCashEquivalentsAtCarryingValue { get; set; }
+	public decimal? CashAndShortTermInvestments { get; set; }
+	public decimal? Inventory { get; set; }
+	public decimal? CurrentNetReceivables { get; set; }
+	public decimal? TotalNonCurrentAssets { get; set; }
+	public decimal? PropertyPlantEquipment { get; set; }
+	public decimal? AccumulatedDepreciationAmortizationPPE { get; set; }
+	public decimal? IntangibleAssets { get; set; }
+	public decimal? IntangibleAssetsExcludingGoodwill { get; set; }
+	public decimal? Goodwill { get; set; }
+	public decimal? Investments { get; set; }
+	public decimal? LongTermInvestments { get; set; }
+	public decimal? ShortTermInvestments { get; set; }
+	public decimal? OtherCurrentAssets { get; set; }
+	public decimal? OtherNonCurrentAssets { get; set; }
+	public decimal? TotalLiabilities { get; set; }
+	public decimal? TotalCurrentLiabilities { get; set; }
+	public decimal? CurrentAccountsPayable { get; set; }
+	public decimal? DeferredRevenue { get; set; }
+	public decimal? CurrentDebt { get; set; }
+	public decimal? ShortTermDebt { get; set; }
+	public decimal? TotalNonCurrentLiabilities { get; set; }
+	public decimal? CapitalLeaseObligations { get; set; }
+	public decimal? LongTermDebt { get; set; }
+	public decimal? CurrentLongTermDebt { get; set; }
+	public decimal? LongTermDebtNoncurrent { get; set; }
+	public decimal? ShortLongTermDebtTotal { get; set; }
+	public decimal? OtherCurrentLiabilities { get; set; }
+	public decimal? OtherNonCurrentLiabilities { get; set; }
+	public decimal? TotalShareholderEquity { get; set; }
+	public decimal? TreasuryStock { get; set; }
+	public decimal? RetainedEarnings { get; set; }
+	public decimal? CommonStock { get; set; }
+	public decimal? CommonStockSharesOutstanding { get; set; }
 #pragma warning restore CS1591
 }

--- a/Source/AlphaVantage.Net/Fundamentals/CashFlowResponse.cs
+++ b/Source/AlphaVantage.Net/Fundamentals/CashFlowResponse.cs
@@ -20,32 +20,32 @@ public class CashFlowReport
 #pragma warning disable CS1591
 	public required DateOnly FiscalDateEnding { get; set; }
 	public required string ReportedCurrency { get; set; }
-	public required decimal? OperatingCashflow { get; set; }
-	public required decimal? PaymentsForOperatingActivities { get; set; }
-	public required decimal? ProceedsFromOperatingActivities { get; set; }
-	public required decimal? ChangeInOperatingLiabilities { get; set; }
-	public required decimal? ChangeInOperatingAssets { get; set; }
-	public required decimal? DepreciationDepletionAndAmortization { get; set; }
-	public required decimal? CapitalExpenditures { get; set; }
-	public required decimal? ChangeInReceivables { get; set; }
-	public required decimal? ChangeInInventory { get; set; }
-	public required decimal? ProfitLoss { get; set; }
-	public required decimal? CashflowFromInvestment { get; set; }
-	public required decimal? CashflowFromFinancing { get; set; }
-	public required decimal? ProceedsFromRepaymentsOfShortTermDebt { get; set; }
-	public required decimal? PaymentsForRepurchaseOfCommonStock { get; set; }
-	public required decimal? PaymentsForRepurchaseOfEquity { get; set; }
-	public required decimal? PaymentsForRepurchaseOfPreferredStock { get; set; }
-	public required decimal? DividendPayout { get; set; }
-	public required decimal? DividendPayoutCommonStock { get; set; }
-	public required decimal? DividendPayoutPreferredStock { get; set; }
-	public required decimal? ProceedsFromIssuanceOfCommonStock { get; set; }
-	public required decimal? ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet { get; set; }
-	public required decimal? ProceedsFromIssuanceOfPreferredStock { get; set; }
-	public required decimal? ProceedsFromRepurchaseOfEquity { get; set; }
-	public required decimal? ProceedsFromSaleOfTreasuryStock { get; set; }
-	public required decimal? ChangeInCashAndCashEquivalents { get; set; }
-	public required decimal? ChangeInExchangeRate { get; set; }
-	public required decimal? NetIncome { get; set; }
+	public decimal? OperatingCashflow { get; set; }
+	public decimal? PaymentsForOperatingActivities { get; set; }
+	public decimal? ProceedsFromOperatingActivities { get; set; }
+	public decimal? ChangeInOperatingLiabilities { get; set; }
+	public decimal? ChangeInOperatingAssets { get; set; }
+	public decimal? DepreciationDepletionAndAmortization { get; set; }
+	public decimal? CapitalExpenditures { get; set; }
+	public decimal? ChangeInReceivables { get; set; }
+	public decimal? ChangeInInventory { get; set; }
+	public decimal? ProfitLoss { get; set; }
+	public decimal? CashflowFromInvestment { get; set; }
+	public decimal? CashflowFromFinancing { get; set; }
+	public decimal? ProceedsFromRepaymentsOfShortTermDebt { get; set; }
+	public decimal? PaymentsForRepurchaseOfCommonStock { get; set; }
+	public decimal? PaymentsForRepurchaseOfEquity { get; set; }
+	public decimal? PaymentsForRepurchaseOfPreferredStock { get; set; }
+	public decimal? DividendPayout { get; set; }
+	public decimal? DividendPayoutCommonStock { get; set; }
+	public decimal? DividendPayoutPreferredStock { get; set; }
+	public decimal? ProceedsFromIssuanceOfCommonStock { get; set; }
+	public decimal? ProceedsFromIssuanceOfLongTermDebtAndCapitalSecuritiesNet { get; set; }
+	public decimal? ProceedsFromIssuanceOfPreferredStock { get; set; }
+	public decimal? ProceedsFromRepurchaseOfEquity { get; set; }
+	public decimal? ProceedsFromSaleOfTreasuryStock { get; set; }
+	public decimal? ChangeInCashAndCashEquivalents { get; set; }
+	public decimal? ChangeInExchangeRate { get; set; }
+	public decimal? NetIncome { get; set; }
 #pragma warning restore CS1591
 }

--- a/Source/AlphaVantage.Net/Fundamentals/CompanySummaryResponse.cs
+++ b/Source/AlphaVantage.Net/Fundamentals/CompanySummaryResponse.cs
@@ -21,44 +21,44 @@ public sealed class CompanySummaryResponse
 	public required string Industry { get; set; }
 	public required string Address { get; set; }
 	public required string FiscalYearEnd { get; set; }
-	public required DateOnly? LatestQuarter { get; set; }
-	public required decimal? MarketCapitalization { get; set; }
-	public required decimal? EBITDA { get; set; }
-	public required decimal? PERatio { get; set; }
-	public required decimal? PEGRatio { get; set; }
-	public required decimal? BookValue { get; set; }
-	public required decimal? DividendPerShare { get; set; }
-	public required decimal? DividendYield { get; set; }
-	public required decimal? EPS { get; set; }
-	public required decimal? RevenuePerShareTTM { get; set; }
-	public required decimal? ProfitMargin { get; set; }
-	public required decimal? OperatingMarginTTM { get; set; }
-	public required decimal? ReturnOnAssetsTTM { get; set; }
-	public required decimal? ReturnOnEquityTTM { get; set; }
-	public required decimal? RevenueTTM { get; set; }
-	public required decimal? GrossProfitTTM { get; set; }
-	public required decimal? DilutedEPSTTM { get; set; }
-	public required decimal? QuarterlyEarningsGrowthYOY { get; set; }
-	public required decimal? QuarterlyRevenueGrowthYOY { get; set; }
-	public required decimal? AnalystTargetPrice { get; set; }
-	public required decimal? TrailingPE { get; set; }
-	public required decimal? ForwardPE { get; set; }
-	public required decimal? PriceToSalesRatioTTM { get; set; }
-	public required decimal? PriceToBookRatio { get; set; }
-	public required decimal? EVToRevenue { get; set; }
-	public required decimal? EVToEBITDA { get; set; }
-	public required decimal? Beta { get; set; }
+	public DateOnly? LatestQuarter { get; set; }
+	public decimal? MarketCapitalization { get; set; }
+	public decimal? EBITDA { get; set; }
+	public decimal? PERatio { get; set; }
+	public decimal? PEGRatio { get; set; }
+	public decimal? BookValue { get; set; }
+	public decimal? DividendPerShare { get; set; }
+	public decimal? DividendYield { get; set; }
+	public decimal? EPS { get; set; }
+	public decimal? RevenuePerShareTTM { get; set; }
+	public decimal? ProfitMargin { get; set; }
+	public decimal? OperatingMarginTTM { get; set; }
+	public decimal? ReturnOnAssetsTTM { get; set; }
+	public decimal? ReturnOnEquityTTM { get; set; }
+	public decimal? RevenueTTM { get; set; }
+	public decimal? GrossProfitTTM { get; set; }
+	public decimal? DilutedEPSTTM { get; set; }
+	public decimal? QuarterlyEarningsGrowthYOY { get; set; }
+	public decimal? QuarterlyRevenueGrowthYOY { get; set; }
+	public decimal? AnalystTargetPrice { get; set; }
+	public decimal? TrailingPE { get; set; }
+	public decimal? ForwardPE { get; set; }
+	public decimal? PriceToSalesRatioTTM { get; set; }
+	public decimal? PriceToBookRatio { get; set; }
+	public decimal? EVToRevenue { get; set; }
+	public decimal? EVToEBITDA { get; set; }
+	public decimal? Beta { get; set; }
 	[JsonPropertyName("52WeekHigh")]
-	public required decimal? _52WeekHigh { get; set; }
+	public decimal? _52WeekHigh { get; set; }
 	[JsonPropertyName("52WeekLow")]
-	public required decimal? _52WeekLow { get; set; }
+	public decimal? _52WeekLow { get; set; }
 	[JsonPropertyName("50DayMovingAverage")]
-	public required decimal? _50DayMovingAverage { get; set; }
+	public decimal? _50DayMovingAverage { get; set; }
 	[JsonPropertyName("200DayMovingAverage")]
-	public required decimal? _200DayMovingAverage { get; set; }
-	public required decimal? SharesOutstanding { get; set; }
-	public required DateOnly? DividendDate { get; set; }
-	public required DateOnly? ExDividendDate { get; set; }
+	public decimal? _200DayMovingAverage { get; set; }
+	public decimal? SharesOutstanding { get; set; }
+	public DateOnly? DividendDate { get; set; }
+	public DateOnly? ExDividendDate { get; set; }
 #pragma warning restore CA1707
 #pragma warning restore CS1591
 }

--- a/Source/AlphaVantage.Net/Fundamentals/EarningsCalendarResponse.cs
+++ b/Source/AlphaVantage.Net/Fundamentals/EarningsCalendarResponse.cs
@@ -17,7 +17,7 @@ public class EarningsCalendarResponse
 	[Name("fiscalDateEnding")]
 	public required DateOnly FiscalDateEnding { get; set; }
 	[Name("estimate"), NullValues("")]
-	public required decimal? Estimate { get; set; }
+	public decimal? Estimate { get; set; }
 	[Name("currency")]
 	public required string Currency { get; set; }
 #pragma warning restore CS1591

--- a/Source/AlphaVantage.Net/Fundamentals/EarningsResponse.cs
+++ b/Source/AlphaVantage.Net/Fundamentals/EarningsResponse.cs
@@ -21,7 +21,7 @@ public class AnnualEarnings
 {
 #pragma warning disable CS1591
 	public required DateOnly FiscalDateEnding { get; set; }
-	public required decimal? ReportedEPS { get; set; }
+	public decimal? ReportedEPS { get; set; }
 #pragma warning restore CS1591
 }
 
@@ -33,9 +33,9 @@ public class QuarterlyEarnings
 #pragma warning disable CS1591
 	public required DateOnly FiscalDateEnding { get; set; }
 	public required DateOnly ReportedDate { get; set; }
-	public required decimal? ReportedEPS { get; set; }
-	public required decimal? EstimatedEPS { get; set; }
-	public required decimal? Surprise { get; set; }
-	public required decimal? SurprisePercentage { get; set; }
+	public decimal? ReportedEPS { get; set; }
+	public decimal? EstimatedEPS { get; set; }
+	public decimal? Surprise { get; set; }
+	public decimal? SurprisePercentage { get; set; }
 #pragma warning restore CS1591
 }

--- a/Source/AlphaVantage.Net/Fundamentals/IncomeStatementResponse.cs
+++ b/Source/AlphaVantage.Net/Fundamentals/IncomeStatementResponse.cs
@@ -20,29 +20,29 @@ public class IncomeStatementReport
 #pragma warning disable CS1591
 	public required DateOnly FiscalDateEnding { get; set; }
 	public required string ReportedCurrency { get; set; }
-	public required decimal? GrossProfit { get; set; }
-	public required decimal? TotalRevenue { get; set; }
-	public required decimal? CostOfRevenue { get; set; }
-	public required decimal? CostofGoodsAndServicesSold { get; set; }
-	public required decimal? OperatingIncome { get; set; }
-	public required decimal? SellingGeneralAndAdministrative { get; set; }
-	public required decimal? ResearchAndDevelopment { get; set; }
-	public required decimal? OperatingExpenses { get; set; }
-	public required decimal? InvestmentIncomeNet { get; set; }
-	public required decimal? NetInterestIncome { get; set; }
-	public required decimal? InterestIncome { get; set; }
-	public required decimal? InterestExpense { get; set; }
-	public required decimal? NonInterestIncome { get; set; }
-	public required decimal? OtherNonOperatingIncome { get; set; }
-	public required decimal? Depreciation { get; set; }
-	public required decimal? DepreciationAndAmortization { get; set; }
-	public required decimal? IncomeBeforeTax { get; set; }
-	public required decimal? IncomeTaxExpense { get; set; }
-	public required decimal? InterestAndDebtExpense { get; set; }
-	public required decimal? NetIncomeFromContinuingOperations { get; set; }
-	public required decimal? ComprehensiveIncomeNetOfTax { get; set; }
-	public required decimal? Ebit { get; set; }
-	public required decimal? Ebitda { get; set; }
-	public required decimal? NetIncome { get; set; }
+	public decimal? GrossProfit { get; set; }
+	public decimal? TotalRevenue { get; set; }
+	public decimal? CostOfRevenue { get; set; }
+	public decimal? CostofGoodsAndServicesSold { get; set; }
+	public decimal? OperatingIncome { get; set; }
+	public decimal? SellingGeneralAndAdministrative { get; set; }
+	public decimal? ResearchAndDevelopment { get; set; }
+	public decimal? OperatingExpenses { get; set; }
+	public decimal? InvestmentIncomeNet { get; set; }
+	public decimal? NetInterestIncome { get; set; }
+	public decimal? InterestIncome { get; set; }
+	public decimal? InterestExpense { get; set; }
+	public decimal? NonInterestIncome { get; set; }
+	public decimal? OtherNonOperatingIncome { get; set; }
+	public decimal? Depreciation { get; set; }
+	public decimal? DepreciationAndAmortization { get; set; }
+	public decimal? IncomeBeforeTax { get; set; }
+	public decimal? IncomeTaxExpense { get; set; }
+	public decimal? InterestAndDebtExpense { get; set; }
+	public decimal? NetIncomeFromContinuingOperations { get; set; }
+	public decimal? ComprehensiveIncomeNetOfTax { get; set; }
+	public decimal? Ebit { get; set; }
+	public decimal? Ebitda { get; set; }
+	public decimal? NetIncome { get; set; }
 #pragma warning restore CS1591
 }

--- a/Source/AlphaVantage.Net/Fundamentals/IpoCalendarResponse.cs
+++ b/Source/AlphaVantage.Net/Fundamentals/IpoCalendarResponse.cs
@@ -15,9 +15,9 @@ public class IpoCalendarResponse
 	[Name("ipoDate")]
 	public required DateOnly IpoDate { get; set; }
 	[Name("priceRangeLow"), NullValues("")]
-	public required decimal? PriceRangeLow { get; set; }
+	public decimal? PriceRangeLow { get; set; }
 	[Name("priceRangeHigh"), NullValues("")]
-	public required decimal? PriceRangeHigh { get; set; }
+	public decimal? PriceRangeHigh { get; set; }
 	[Name("currency")]
 	public required string Currency { get; set; }
 	[Name("exchange")]

--- a/Source/AlphaVantage.Net/Fundamentals/ListingStatusResponse.cs
+++ b/Source/AlphaVantage.Net/Fundamentals/ListingStatusResponse.cs
@@ -19,7 +19,7 @@ public class ListingStatusResponse
 	[Name("ipoDate")]
 	public required DateOnly IpoDate { get; set; }
 	[Name("delistingDate"), NullValues("null")]
-	public required DateOnly? DelistingDate { get; set; }
+	public DateOnly? DelistingDate { get; set; }
 	[Name("status")]
 	public required string Status { get; set; }
 #pragma warning restore CS1591

--- a/Source/AlphaVantage.Net/Stocks/DailyAdjustedTimeSeriesResponse.cs
+++ b/Source/AlphaVantage.Net/Stocks/DailyAdjustedTimeSeriesResponse.cs
@@ -12,20 +12,20 @@ public class DailyAdjustedTimeSeriesResponse
 	[Name("timestamp")]
 	public required DateTime Timestamp { get; set; }
 	[Name("open"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? Open { get; set; }
+	public decimal? Open { get; set; }
 	[Name("high"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? High { get; set; }
+	public decimal? High { get; set; }
 	[Name("low"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? Low { get; set; }
+	public decimal? Low { get; set; }
 	[Name("close"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? Close { get; set; }
+	public decimal? Close { get; set; }
 	[Name("adjusted_close"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? AdjustedClose { get; set; }
+	public decimal? AdjustedClose { get; set; }
 	[Name("volume"), NullValues("", "null")]
-	public required long? Volume { get; set; }
+	public long? Volume { get; set; }
 	[Name("dividend_amount"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? DividendAmount { get; set; }
+	public decimal? DividendAmount { get; set; }
 	[Name("split_coefficient"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? SplitCoefficient { get; set; }
+	public decimal? SplitCoefficient { get; set; }
 #pragma warning restore CS1591
 }

--- a/Source/AlphaVantage.Net/Stocks/QuoteResponse.cs
+++ b/Source/AlphaVantage.Net/Stocks/QuoteResponse.cs
@@ -14,21 +14,21 @@ public class QuoteResponse
 	[Name("symbol")]
 	public required string Symbol { get; set; }
 	[Name("open"), NullValues("", "null")]
-	public required decimal? Open { get; set; }
+	public decimal? Open { get; set; }
 	[Name("high"), NullValues("", "null")]
-	public required decimal? High { get; set; }
+	public decimal? High { get; set; }
 	[Name("low"), NullValues("", "null")]
-	public required decimal? Low { get; set; }
+	public decimal? Low { get; set; }
 	[Name("volume"), NullValues("", "null")]
-	public required long? Volume { get; set; }
+	public long? Volume { get; set; }
 	[Name("latestDay"), NullValues("", "null")]
-	public required DateOnly? LatestDay { get; set; }
+	public DateOnly? LatestDay { get; set; }
 	[Name("previousClose"), NullValues("", "null")]
-	public required decimal? PreviousClose { get; set; }
+	public decimal? PreviousClose { get; set; }
 	[Name("change"), NullValues("", "null")]
-	public required decimal? Change { get; set; }
+	public decimal? Change { get; set; }
 	[Name("changePercent"), NullValues("", "null"), TypeConverter(typeof(PercentConverter))]
-	public required decimal? ChangePercent { get; set; }
+	public decimal? ChangePercent { get; set; }
 
 	private class PercentConverter : ITypeConverter
 	{

--- a/Source/AlphaVantage.Net/Stocks/TimeSeriesResponse.cs
+++ b/Source/AlphaVantage.Net/Stocks/TimeSeriesResponse.cs
@@ -12,14 +12,14 @@ public class TimeSeriesResponse
 	[Name("timestamp", "time")]
 	public required DateTime Timestamp { get; set; }
 	[Name("open"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? Open { get; set; }
+	public decimal? Open { get; set; }
 	[Name("high"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? High { get; set; }
+	public decimal? High { get; set; }
 	[Name("low"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? Low { get; set; }
+	public decimal? Low { get; set; }
 	[Name("close"), NullValues("", "null"), NumberStyles(NumberStyles.Float)]
-	public required decimal? Close { get; set; }
+	public decimal? Close { get; set; }
 	[Name("volume"), NullValues("", "null")]
-	public required long? Volume { get; set; }
+	public long? Volume { get; set; }
 #pragma warning restore CS1591
 }


### PR DESCRIPTION
This PR updates all models to remove the `required` expectation for nullable fields; they may not be present if serialized and deserialized, and it should not be an error for them to be missing.